### PR TITLE
[#25] `SmartFile::$type` can never be null

### DIFF
--- a/src/SmartFile.php
+++ b/src/SmartFile.php
@@ -42,7 +42,7 @@ final readonly class SmartFile implements \Stringable
     public string $name;
     public string $basename;
     public ?string $extension;
-    public ?FileType $type;
+    public FileType $type;
 
     /**
      * @var non-empty-string


### PR DESCRIPTION
**Issues**
- #25